### PR TITLE
Add `bundler` parameter to `ExecutionContext`

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ This adapter uses SSH console client to connect to the remote machine, launches 
 | working_dir | String | no | ~ | Path to the directory on the remote server where the script should be executed |
 | user | String | no | - | User on the remote host to connect as |
 | key_file| String | no | - | Path to the private SSH key |
+| bundler | Boolean | no | false | Specifies, whether the code should be executed with `bundle exec` on the remote server |
 
 
 #### Local STDIN adapter
@@ -338,6 +339,7 @@ This adapter changes to the specified directory on the **local** machine, launch
 | Parameter | Type | Required | Default value | Description |
 | --------- | ---- | ---------| ------------- | ----------- |
 | working_dir | String | no | . | Path to the directory on the local machine where the script should be executed |
+| bundler | Boolean | no | false | Specifies, whether the code should be executed with `bundle exec` |
 
 
 #### Evaluating adapter

--- a/lib/remote_ruby/connection_adapter/local_stdin_adapter.rb
+++ b/lib/remote_ruby/connection_adapter/local_stdin_adapter.rb
@@ -4,11 +4,12 @@ module RemoteRuby
   # An adapter to expecute Ruby code on the local macine
   # inside a specified directory
   class LocalStdinAdapter < ::RemoteRuby::StdinProcessAdapter
-    attr_reader :working_dir
+    attr_reader :working_dir, :bundler
 
-    def initialize(working_dir: '.')
+    def initialize(working_dir: '.', bundler: false)
       super
       @working_dir = working_dir
+      @bundler = bundler
     end
 
     def connection_name
@@ -18,7 +19,11 @@ module RemoteRuby
     private
 
     def command
-      "cd \"#{working_dir}\" && ruby"
+      if bundler
+        "cd \"#{working_dir}\" && bundle exec ruby"
+      else
+        "cd \"#{working_dir}\" && ruby"
+      end
     end
   end
 end

--- a/lib/remote_ruby/connection_adapter/ssh_stdin_adapter.rb
+++ b/lib/remote_ruby/connection_adapter/ssh_stdin_adapter.rb
@@ -3,14 +3,15 @@
 module RemoteRuby
   # An adapter to execute Ruby code on the remote server via SSH
   class SSHStdinAdapter < StdinProcessAdapter
-    attr_reader :server, :working_dir, :user, :key_file
+    attr_reader :server, :working_dir, :user, :key_file, :bundler
 
-    def initialize(server:, working_dir: '~', user: nil, key_file: nil)
+    def initialize(server:, working_dir: '~', user: nil, key_file: nil, bundler: false)
       super
       @working_dir = working_dir
       @server = user.nil? ? server : "#{user}@#{server}"
       @user = user
       @key_file = key_file
+      @bundler = bundler
     end
 
     def connection_name
@@ -22,7 +23,12 @@ module RemoteRuby
     def command
       command = 'ssh'
       command = "#{command} -i #{key_file}" if key_file
-      "#{command} #{server} \"cd #{working_dir} && ruby\""
+
+      if bundler
+        "#{command} #{server} \"cd #{working_dir} && bundle exec ruby\""
+      else
+        "#{command} #{server} \"cd #{working_dir} && ruby\""
+      end
     end
   end
 end

--- a/lib/remote_ruby/version.rb
+++ b/lib/remote_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RemoteRuby
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/remote_ruby.gemspec
+++ b/remote_ruby.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'base64', '~> 0.2'
-  spec.add_runtime_dependency 'colorize', '~> 0.8'
-  spec.add_runtime_dependency 'method_source', '~> 1.0'
-  spec.add_runtime_dependency 'parser', '~> 3.0'
-  spec.add_runtime_dependency 'unparser', '~> 0.6'
+  spec.add_dependency 'base64', '~> 0.2'
+  spec.add_dependency 'colorize', '~> 0.8'
+  spec.add_dependency 'method_source', '~> 1.0'
+  spec.add_dependency 'parser', '~> 3.0'
+  spec.add_dependency 'unparser', '~> 0.6'
 end

--- a/spec/remote_ruby/compiler_spec.rb
+++ b/spec/remote_ruby/compiler_spec.rb
@@ -45,7 +45,7 @@ describe RemoteRuby::Compiler do
       end
 
       context 'when local cannot be dumped' do
-        let(:client_locals) { { file: File.open('/dev/null', 'w') } }
+        let(:client_locals) { { file: File.open(File::NULL, 'w') } }
         it 'prints out a warning' do
           expect { compiled_code }.to output(/file/).to_stderr
         end


### PR DESCRIPTION
To address issue #3 this introduces a new `bundler` parameter which allows STDIN-type adapters to execute remote scripts using `bundle exec`.